### PR TITLE
updateを押下時にtokenが切れている場合の問題をfix しかし、noticeが出ないようになってしまった

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,8 +9,15 @@ class SessionsController < ApplicationController
     end
 
     session[:user_id] = user.id
-    redirect_to users_url
+
+    if session[:status] == "update"
+      redirect_to '/users/renew'
+      session[:status] = nil
+    else
+      redirect_to users_url
+    end
   end
+
 
   def destroy
     session[:user_id] = nil

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,10 @@ class SessionsController < ApplicationController
   def create
     auth = request.env["omniauth.auth"]
     user = User.find_by_provider_and_uid(auth["provider"], auth["uid"]) || User.create_with_omniauth(auth)
+    if user.token != auth['credentials']['token']
+      user.token = auth['credentials']['token']
+      user.save
+    end
 
     session[:user_id] = user.id
     redirect_to users_url

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,9 +20,13 @@ class UsersController < ApplicationController
   end
 
   def update
+    session[:status] = "update"
     redirect_to '/auth/facebook'
+  end
+
+  def renew
     save_fb_data
-    # redirect_to '/users', :notice => 'Facebookからデータを取得しました！'
+    redirect_to '/users', :notice => 'Facebookからデータを取得しました！'
   end
 
   def gender

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,8 +20,9 @@ class UsersController < ApplicationController
   end
 
   def update
+    redirect_to '/auth/facebook'
     save_fb_data
-    redirect_to '/users', :notice => 'Facebookからデータを取得しました！'
+    # redirect_to '/users', :notice => 'Facebookからデータを取得しました！'
   end
 
   def gender

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
   validates_uniqueness_of :uid, scope: :provider
 
   def self.create_with_omniauth(auth)
+    binding.pry
     create! do |user|
       user.provider = auth["provider"]
       user.uid      = auth["uid"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ActiveRecord::Base
   validates_uniqueness_of :uid, scope: :provider
 
   def self.create_with_omniauth(auth)
-    binding.pry
     create! do |user|
       user.provider = auth["provider"]
       user.uid      = auth["uid"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get 'users' => 'users#top'
   get 'users/update'
   get 'users/about'
+  get 'users/renew'
 
   get 'users/gender'
   get 'users/age'


### PR DESCRIPTION
issue#1の対策として、
update押下時は、常に /auth/facebookに飛ばすようにした。
その後、session/createにcallbackされた際に、token情報が更新されていれば、DBの中身も更新する。
セッションが切れている場合に動作がどうなるかは要確認

しかし、この方法では、session/createにcallbackされた際に、
/users/topで/auth/facebookが呼ばれたのか、/users/updateで呼ばれたのかわからないので、
noticeを出すことができない。←要対応
